### PR TITLE
IDM-197 Implement JWT bearer token flow in Hydra - fix: check 'aud' claim against Hydra Issuer

### DIFF
--- a/cmd/server/handler_oauth2_factory.go
+++ b/cmd/server/handler_oauth2_factory.go
@@ -59,7 +59,7 @@ func newOAuth2Provider(c *config.Config, km jwk.Manager) fosite.OAuth2Provider {
 	var store = oauth2.CommonStore{
 		FositeStorer: ctx.FositeStore,
 		KeyManager:   km,
-		ClusterURL:   c.ClusterURL,
+		Issuer:       c.Issuer,
 	}
 
 	createRS256KeysIfNotExist(c, oauth2.OpenIDConnectKeyName, "private", "sig")

--- a/oauth2/flow_jwt_bearer.go
+++ b/oauth2/flow_jwt_bearer.go
@@ -30,7 +30,7 @@ func JWTBearerGrantFactory(config *compose.Config, storage interface{}, strategy
 		},
 		ScopeStrategy: fosite.HierarchicScopeStrategy,
 		KeyManager:    storage.(CommonStore).KeyManager,
-		Audience:      strings.Trim(storage.(CommonStore).ClusterURL, "/") + "/oauth2/token",
+		Audience:      strings.Trim(storage.(CommonStore).Issuer, "/") + "/oauth2/token",
 	}
 }
 

--- a/oauth2/store.go
+++ b/oauth2/store.go
@@ -9,5 +9,5 @@ import (
 type CommonStore struct {
 	pkg.FositeStorer
 	KeyManager jwk.Manager
-	ClusterURL string
+	Issuer     string
 }


### PR DESCRIPTION
Use static Hydra Issuer instead of a dynamic Cluster URL for 'aud' claim check in JWT bearer flow.